### PR TITLE
Namespace is not used in alarm name if namespace was not provided

### DIFF
--- a/cloud_watch_client.py
+++ b/cloud_watch_client.py
@@ -228,6 +228,8 @@ class CloudWatchClient:
         return [{key_name: k, 'Value': v} for k, v in my_dict.items()]
 
     def _get_full_normalized_alarm_name(self, alarm_name):
+        if not self._namespace:
+            return self._normalise_string(alarm_name)
         return f"{self._namespace}.{self._normalise_string(alarm_name)}"
 
     def _get_logger(self):


### PR DESCRIPTION
When a namespace is not provided CW client will create an alarm name that started from ".". It is not good when someone what to set or delete alarms from different namespaces. 